### PR TITLE
Reduce size of local development docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+charts
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:current-alpine
 RUN npm install -g http-server
 RUN mkdir /public
 WORKDIR /public


### PR DESCRIPTION
A fix for a too-large docker image for the task

Addresses the 1GB docker image for local dev by changing the FROM to current-alpine, size of image reduced form 1GB to 177MB